### PR TITLE
Handle comma expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xgettext-js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Andrew Duthie <andrew@andrewduthie.com>",
   "description": "xgettext string extractor tool capable of parsing JavaScript files",
   "main": "xgettext.js",

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -80,3 +80,10 @@ it( 'should accept a number as keyword value to represent argument position', fu
 
   expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1 }] );
 });
+
+it( 'should match functions that are the last element of a sequence (comma) expression', function() {
+	var source = '(0, transpilerGeneratedName._)("Hello World!")',
+		matches = new XGettext().getMatches( source );
+
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+});

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -87,3 +87,10 @@ it( 'should match functions that are the last element of a sequence (comma) expr
 
 	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
 });
+
+it( 'should match functions that are the last element of a recursive sequence (comma) expression', function() {
+	var source = '(0, (0, transpilerGeneratedName._))("Hello World!")',
+		matches = new XGettext().getMatches( source );
+
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+});

--- a/xgettext.js
+++ b/xgettext.js
@@ -164,7 +164,9 @@ XGettext.prototype._discoverMatches = function( parsedInput ) {
 
 	traverse( parsedInput.ast, {
 		CallExpression: function( node ) {
-			var functionName = ( node.callee.property ) ? node.callee.property.name : node.callee.name;
+			// Pull the resultingFunction out of (0, resultingFunction)()
+			var callee = ( node.callee.type === 'SequenceExpression' ) ? _.last( node.callee.expressions ) : node.callee;
+			var functionName = ( callee.property ) ? callee.property.name : callee.name;
 
 			// Validate is named function
 			if ( ! functionName ) return;

--- a/xgettext.js
+++ b/xgettext.js
@@ -165,7 +165,10 @@ XGettext.prototype._discoverMatches = function( parsedInput ) {
 	traverse( parsedInput.ast, {
 		CallExpression: function( node ) {
 			// Pull the resultingFunction out of (0, resultingFunction)()
-			var callee = ( node.callee.type === 'SequenceExpression' ) ? _.last( node.callee.expressions ) : node.callee;
+			var callee = node.callee;
+			while ( 'SequenceExpression' === callee.type ) {
+				callee = _.last( callee.expressions );
+			}
 			var functionName = ( callee.property ) ? callee.property.name : callee.name;
 
 			// Validate is named function


### PR DESCRIPTION
This PR adds support for sequence/comma expressions by treating the last value in them as the callee.  For example, if xgettext sees `(0, foo)('bar')` it will extract the last value and treat it like `foo(bar)`.

It includes a version bump so that downstream projects can ensure it is present.

This is desirable because babel generates code like this when transpiling es6 module expressions.

`babel <(echo "import {translate} from 'lib/mixins/i18n'; translate('foo')")`
->
    'use strict';
    
    var _libMixinsI18n = require('lib/mixins/i18n');
    
    (0, _libMixinsI18n.translate)('foo');

I can't imagine why babel is introducing the commas in this way, but the if you run xgettext on the code after it's been transpiled these strings are missed.

This is probably a temporary problem, but it seems like a safe solution.

Fixes https://github.com/Automattic/wp-calypso/issues/3239