### PR TITLE
Allow passing in options for acorn

### DIFF
--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -94,3 +94,26 @@ it( 'should match functions that are the last element of a recursive sequence (c
 
 	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
 });
+
+describe( '#parserOptions', function() {
+	it( 'with ecma6, should fail when parserOptions not set', function() {
+		var source = 'const i = 0; _( "Hello World!" );',
+			parser = new XGettext(),
+			fn = function() {
+				parser.getMatches( source );
+			};
+
+			expect( fn ).to.throw(SyntaxError);
+	});
+
+	it( 'with ecma6, should parse successfully when parserOptions set', function() {
+		var source = 'const i = 0; _( "Hello World!" );',
+			matches = new XGettext( {
+				parserOptions: {
+					ecmaVersion: 6
+				}
+			}).getMatches( source );
+
+		expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1 }] );
+	});
+});

--- a/xgettext.js
+++ b/xgettext.js
@@ -15,6 +15,7 @@ var XGettext = module.exports = function( options ) {
 	this.options = _.extend( {}, XGettext.defaultOptions, options );
 	this.options.keywords = this._normalizeKeywords( this.options.keywords );
 	this.options.keywordFunctions = Object.keys( this.options.keywords );
+	this.options.parserOptions = _.extend( {}, options.parserOptions );
 };
 
 XGettext.defaultOptions = {
@@ -123,7 +124,7 @@ XGettext.prototype._normalizeKeyword = function( keyword ) {
  */
 XGettext.prototype._parseInput = function( input ) {
 	var comments = [],
-		parseOptions = { locations: true },
+		parseOptions = _.extend( { locations: true }, this.options.parserOptions ),
 		ast;
 
 	if ( typeof this.options.commentPrefix !== 'undefined' ) {


### PR DESCRIPTION
`acorn` supports various options, such as setting the ecma version for your source code (https://github.com/ternjs/acorn#main-parser). Allow passing in those options when instantiating the XGettext object.

This is needed for the WordPress.com Desktop app, which currently uses some newer ecma features in untranspiled mode (via `'use strict'`) and we need to be able to parse through and pull out translation strings properly.

/cc @deBhal @aduth 