### PR TITLE
Bump acorn dep to 3.0.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+Version 0.3.0
+=============
+- Updated: Acorn dependency from 0.6.0 to 3.0.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xgettext-js",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": "Andrew Duthie <andrew@andrewduthie.com>",
   "description": "xgettext string extractor tool capable of parsing JavaScript files",
   "main": "xgettext.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "acorn": "^0.6.0",
+    "acorn": "^3.0.4",
     "lodash": "^2.4.1"
   },
   "devDependencies": {

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -94,3 +94,10 @@ it( 'should match functions that are the last element of a recursive sequence (c
 
 	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
 });
+
+it( 'should parse ecma6 by default', function() {
+	var source = 'const i = 0; _("Hello World!");',
+		matches = new XGettext().getMatches( source );
+
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+});

--- a/xgettext.js
+++ b/xgettext.js
@@ -1,6 +1,6 @@
 var _ = require( 'lodash' ),
 	parser = require( 'acorn' ),
-	traverse = require( 'acorn/util/walk' ).simple;
+	traverse = require( 'acorn/dist/walk' ).simple;
 
 /**
  * XGettext will parse a given input string for any instances of i18n function calls,


### PR DESCRIPTION
It defaults to ecma6 plus other improvements.

Alternative to https://github.com/Automattic/xgettext-js/pull/8