### PR TITLE
Upgrade Lodash to 4.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "acorn": "^3.0.4",
-    "lodash": "^2.4.1"
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
This pull request seeks to upgrade the Lodash dependency from ^2.4.1 to ^4.13.1.

[See Changelog](https://github.com/lodash/lodash/wiki/Changelog)

Only the main [`xgettext.js` file](https://github.com/Automattic/xgettext-js/blob/master/xgettext.js) makes use of Lodash, of which it uses a handful of functions:

- `extend`
- `_` (chain)
- `map`
- `flatten`
- `last`
- `each`
- `isPlainObject`

Of these, only `last` has received breaking changes since 2.4.1 ([see notes for 3.0.0 release](https://github.com/lodash/lodash/wiki/Changelog#v300)), but our usage here matches the 3.0.0 behavior.

__Testing instructions:__

Ensure tests pass:

```
npm test
```

/cc @blowery 