### PR TITLE
Add JSX support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,0 @@
-Version 0.3.1
-=============
-- Updated: Lodash dependency from ^2.4.1 to ^4.13.1
-
-Version 0.3.0
-=============
-- Updated: Acorn dependency from 0.6.0 to 3.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Version 1.0.0
+=============
+- Switch to `babylon` as a JavaScript parser.
+    - There are [slight incompatibilities](https://www.npmjs.com/package/babylon#output) in the AST from the previous parser `acorn`.
+    - Advantage of `babylon`: Ability to parse JSX and other advanced ES7 features (all with [enabled plugins](https://www.npmjs.com/package/babylon#plugins) in the `parserOptions`).
+
+Version 0.3.1
+=============
+- Updated: Lodash dependency from ^2.4.1 to ^4.13.1
+
+Version 0.3.0
+=============
+- Updated: Acorn dependency from 0.6.0 to 3.0.4

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ To override the default behavior, you can pass an options object when creating a
 
 ## License
 
-Copyright 2014 Automattic
+Copyright 2016 Automattic
 
 This package is made available under the GPLv2 or later license

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "make test"
   },
   "dependencies": {
-    "acorn": "^3.0.4",
+    "babylon": "^6.8.4",
+    "estree-walker": "0.2.1",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xgettext-js",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "author": "Andrew Duthie <andrew@andrewduthie.com>",
   "description": "xgettext string extractor tool capable of parsing JavaScript files",
   "main": "xgettext.js",
@@ -22,7 +22,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "babylon": "^6.8.4",
+    "babylon": "6.8.4",
     "estree-walker": "0.2.1",
     "lodash": "^4.13.1"
   },


### PR DESCRIPTION
~~This adds JSX support by switching to `acorn-jsx`. Interestingly enough they don't extend the walker elements base, so I am extending it manually with the `JSXElement`.~~

As per recommendation by @aduth this makes it possible to switch the parser to `babylon` which is capable of parsing Calypso with the [right parser options](https://github.com/Automattic/i18n-calypso/pull/13/files#diff-b6e52b89ad89c29a17bf6a53e65888f9R39).