### PR TITLE
Added column information for transform matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var XGettext = require( 'xgettext-js' ),
 	parser = new XGettext();
 
 console.log( parser.getMatches( source ) );
-// Will output: [ { "string": "Hello World!", "comment": "greeting", "line": 1 } ]
+// Will output: [ { "string": "Hello World!", "comment": "greeting", "line": 1, "column": 0 } ]
 ```
 
 ## Options

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -10,21 +10,21 @@ it( 'should return array of translatable strings', function() {
 	var source = '_( "Hello World!" );',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1, column: 0 }] );
 });
 
 it( 'should return array of translatable strings, including comment on same line', function() {
 	var source = '_( "Hello World!" ); /* translators: greeting */',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 1, column: 0 }] );
 });
 
 it( 'should return array of translatable strings, including comment on previous line', function() {
 	var source = '/* translators: greeting */\n_( "Hello World!" );',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 2 }] );
+	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 2, column: 0 }] );
 });
 
 it( 'should enable developer to provide custom keyword logic returning a string', function() {
@@ -42,7 +42,7 @@ it( 'should enable developer to provide custom keyword logic returning a string'
 		}),
 		matches = parser.getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ string: 'greeting\u0004Hello World!', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ string: 'greeting\u0004Hello World!', line: 1, column: 0 }] );
 });
 
 it( 'should enable developer to provide custom keyword logic returning an object', function() {
@@ -66,7 +66,7 @@ it( 'should enable developer to provide custom translator comment prefix', funct
 		}),
 		matches = parser.getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ string: 'Hello World!', comment: 'greeting', line: 1, column: 0 }] );
 });
 
 it( 'should accept a number as keyword value to represent argument position', function() {
@@ -78,26 +78,26 @@ it( 'should accept a number as keyword value to represent argument position', fu
     }),
     matches = parser.getMatches( source );
 
-  expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1 }] );
+  expect( matches ).to.deep.equal( [{ string: 'Hello World!', line: 1, column: 0 }] );
 });
 
 it( 'should match functions that are the last element of a sequence (comma) expression', function() {
 	var source = '(0, transpilerGeneratedName._)("Hello World!")',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1, column: 0 }] );
 });
 
 it( 'should match functions that are the last element of a recursive sequence (comma) expression', function() {
 	var source = '(0, (0, transpilerGeneratedName._))("Hello World!")',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1, column: 0 }] );
 });
 
 it( 'should parse ecma6 by default', function() {
 	var source = 'const i = 0; _("Hello World!");',
 		matches = new XGettext().getMatches( source );
 
-	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1 }] );
+	expect( matches ).to.deep.equal( [{ 'string': 'Hello World!', line: 1, column: 13 }] );
 });

--- a/xgettext.js
+++ b/xgettext.js
@@ -146,7 +146,8 @@ XGettext.prototype._parseInput = function( input ) {
 			if ( isTranslatorComment ) {
 				comments.push({
 					value: text.replace( rxCommentMatch, '' ).trim(),
-					line: comment.loc.start
+					line: comment.loc.start.line,
+					column: comment.loc.start.column
 				});
 			}
 		} );
@@ -192,13 +193,14 @@ XGettext.prototype._discoverMatches = function( parsedInput ) {
 			var match = {
 				arguments: node.arguments,
 				keyword: functionName,
-				line: node.loc.start.line
+				line: node.loc.start.line,
+				column: node.loc.start.column
 			};
 
 			// Find translator comment
 			_.each( parsedInput.comments, function( translatorComment ) {
-				if ( node.loc.start.line === translatorComment.line.line ||
-					node.loc.start.line - 1 === translatorComment.line.line ) {
+				if ( node.loc.start.line === translatorComment.line ||
+					node.loc.start.line - 1 === translatorComment.line ) {
 					match.comment = translatorComment.value;
 				}
 			});
@@ -234,7 +236,7 @@ XGettext.prototype._transformMatch = function( match ) {
 
 	// Transform string back to object with comment
 	strings = _.map(strings, function( string ) {
-		var transformed = { string: string, line: match.line };
+		var transformed = { string: string, line: match.line, column: match.column };
 
 		if ( typeof match.comment !== 'undefined' ) {
 			transformed.comment = match.comment;

--- a/xgettext.js
+++ b/xgettext.js
@@ -146,8 +146,7 @@ XGettext.prototype._parseInput = function( input ) {
 			if ( isTranslatorComment ) {
 				comments.push({
 					value: text.replace( rxCommentMatch, '' ).trim(),
-					line: comment.loc.start.line,
-					column: comment.loc.start.column
+					line: comment.loc.start.line
 				});
 			}
 		} );


### PR DESCRIPTION
This patch makes the `column` field available for transform matchers for those of us interested in such things.