### PR TITLE
Update parser and walker to handle latest JSX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/parser": {
+      "version": "7.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.48.tgz",
+      "integrity": "sha512-X3pKxvy7vL79zc/6XS6cCObyuRMnsRGRu7d3zVSPZGCdxkK0/wTeFRwseRjcvhReV/6LW2D8H8qHVFFL0c+5+w=="
+    },
     "acorn": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
@@ -133,11 +138,6 @@
           }
         }
       }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -500,9 +500,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
     },
     "esutils": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "babylon": "^6.8.4",
-    "estree-walker": "^0.3.0",
+    "@babel/parser": "^7.0.0-beta.48",
+    "estree-walker": "^0.5.2",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -102,9 +102,13 @@ it( 'should parse ecma6 by default', function() {
 	expect( matches ).to.deep.equal( [ { string: 'Hello World!', line: 1, column: 13 } ] );
 } );
 
-it( 'should handle jsx by default', function() {
+it( 'should handle jsx', function() {
 	var source = '<MyComponent translatedProp={ _( "Hello " ) }>{ _( "World!" ) }</MyComponent>',
-		matches = new XGettext().getMatches( source );
+		matches = new XGettext( {
+			parseOptions: {
+				plugins: [ 'jsx' ],
+			},
+		} ).getMatches( source );
 
 	expect( matches ).to.deep.equal( [
 		{ string: 'Hello ', line: 1, column: 30 },

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -101,3 +101,13 @@ it( 'should parse ecma6 by default', function() {
 
 	expect( matches ).to.deep.equal( [ { string: 'Hello World!', line: 1, column: 13 } ] );
 } );
+
+it( 'should handle jsx by default', function() {
+	var source = '<MyComponent translatedProp={ _( "Hello " ) }>{ _( "World!" ) }</MyComponent>',
+		matches = new XGettext().getMatches( source );
+
+	expect( matches ).to.deep.equal( [
+		{ string: 'Hello ', line: 1, column: 30 },
+		{ string: 'World!', line: 1, column: 48 },
+	] );
+} );

--- a/test/xgettext.js
+++ b/test/xgettext.js
@@ -103,7 +103,7 @@ it( 'should parse ecma6 by default', function() {
 } );
 
 it( 'should handle jsx', function() {
-	var source = '<MyComponent translatedProp={ _( "Hello " ) }>{ _( "World!" ) }</MyComponent>',
+	var source = '<><MyComponent translatedProp={ _( "Hello " ) }>{ _( "World!" ) }</MyComponent></>',
 		matches = new XGettext( {
 			parseOptions: {
 				plugins: [ 'jsx' ],
@@ -111,7 +111,7 @@ it( 'should handle jsx', function() {
 		} ).getMatches( source );
 
 	expect( matches ).to.deep.equal( [
-		{ string: 'Hello ', line: 1, column: 30 },
-		{ string: 'World!', line: 1, column: 48 },
+		{ string: 'Hello ', line: 1, column: 32 },
+		{ string: 'World!', line: 1, column: 50 },
 	] );
 } );

--- a/xgettext.js
+++ b/xgettext.js
@@ -1,5 +1,5 @@
 var _ = require( 'lodash' ),
-	parser = require( 'babylon' ),
+	parser = require( '@babel/parser' ),
 	walk = require( 'estree-walker' ).walk;
 
 /**
@@ -57,7 +57,11 @@ XGettext.defaultOptions = {
 	 * @type {Object}
 	 * @see https://www.npmjs.com/package/babylon
 	 */
-	parseOptions: {},
+	parseOptions: {
+		plugins: [
+			'jsx',
+		],
+	},
 };
 
 /**

--- a/xgettext.js
+++ b/xgettext.js
@@ -55,13 +55,9 @@ XGettext.defaultOptions = {
 	 * Options for the parser. Babylon has some extra ones.
 	 *
 	 * @type {Object}
-	 * @see https://www.npmjs.com/package/babylon
+	 * @see https://www.npmjs.com/package/@babel/parser
 	 */
-	parseOptions: {
-		plugins: [
-			'jsx',
-		],
-	},
+	parseOptions: {},
 };
 
 /**


### PR DESCRIPTION
`babylon` is deprecated, use `@babel/parser` instead.

Add the `jsx` parser plugin.

Add a JSX translation test.