### PR TITLE
Update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "4"
+  - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "lts/*"
+  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: node_js
 node_js:
+  - "4"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
   - "lts/*"
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
-  - "7"
-  - "8"
-  - "9"
-  - "10"
   - "lts/*"
   - "node"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-watch": "mocha --watch"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "dependencies": {
     "babylon": "^6.8.4",


### PR DESCRIPTION
Use LTS and latest stable for travis testing (should be future proof).

Add current existing explicit versions 4-10 to match package.json engines.