### PR TITLE
README: Use master branch build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xgettext-js
 
-[![Build Status](https://travis-ci.org/Automattic/xgettext-js.svg)](https://travis-ci.org/Automattic/xgettext-js)
+[![Build Status](https://travis-ci.org/Automattic/xgettext-js.svg?branch=master)](https://travis-ci.org/Automattic/xgettext-js)
 [![NPM version](https://badge.fury.io/js/xgettext-js.svg)](http://badge.fury.io/js/xgettext-js)
 
 xgettext-js is a utility for extracting translatable strings, written in and capable of parsing JavaScript files. It is similar to the [GNU xgettext](http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html) program, but returns strings as a JavaScript array. It makes use of [babylon](http://github.com/babel/babylon/) and [estree-walker](https://github.com/Rich-Harris/estree-walker) to parse JavaScript code, which facilitates the use of custom logic for string extraction. Because of this, xgettext-js is quite flexible, allowing you to define your own logic for extracting strings from any number of function keywords.


### PR DESCRIPTION
The build badge does not appear to be using the master branch builds.
Update to ensure the master branch build status is displayed in the
README.