### PR TITLE
Prep 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.0.0 (2018-06-FIXME)
+===================
+- Breaking: Support Node v6 or greater (#16).
+- Updated: Switch parser from deprecated babylon to @babel/parser (#14).
+
 v1.1.0 (2016-10-31)
 ===================
 - New: `#getMatches()` now returns `column` in the match result (#13, props @anoek)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v2.0.0 (2018-06-FIXME)
+v2.0.0 (2018-06-07)
 ===================
 - Breaking: Support Node v6 or greater (#16).
 - Updated: Switch parser from deprecated babylon to @babel/parser (#14).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xgettext-js",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Andrew Duthie <andrew@andrewduthie.com>",
   "description": "xgettext string extractor tool capable of parsing JavaScript files",
   "main": "xgettext.js",


### PR DESCRIPTION
Bump package version to 2.0.0 (next major).
Add changelog with significant details from #16 and #14 ✅.